### PR TITLE
#67 Added an option to control NP cast behavior

### DIFF
--- a/FGO_CN_REGULAR.lua
+++ b/FGO_CN_REGULAR.lua
@@ -79,6 +79,14 @@ Autoskill_List[10] = ""
 --可以用這個選項組藍卡隊了安安。這個選項會影響卡片選擇優先順位，例：BAQ代表weak buster->buster->resist buster->weak arts->arts->resist arts->weak quick->quick->resist quick
 Battle_CardPriority = "BAQ"
 
+--[[
+Options:
+• disabled: will never cast NPs automatically, except for Autoskill commands
+• danger: will cast NPs only when there are DANGER or SERVANT enemies on screen
+• spam: will cast NPs as soon as they are available
+--]]
+Battle_NoblePhantasm = "danger" 
+
 --若活動有另外的獎勵視窗需點選，isEvent = 1。 詳細請見github上的readme。
 isEvent = 0
 

--- a/FGO_CN_REGULAR.lua
+++ b/FGO_CN_REGULAR.lua
@@ -85,7 +85,7 @@ Options:
 • danger: will cast NPs only when there are DANGER or SERVANT enemies on screen
 • spam: will cast NPs as soon as they are available
 --]]
-Battle_NoblePhantasm = "danger" 
+Battle_NoblePhantasm = "disabled"
 
 --若活動有另外的獎勵視窗需點選，isEvent = 1。 詳細請見github上的readme。
 isEvent = 0

--- a/FGO_EN_REGULAR.lua
+++ b/FGO_EN_REGULAR.lua
@@ -85,7 +85,7 @@ Options:
 • danger: will cast NPs only when there are DANGER or SERVANT enemies on screen
 • spam: will cast NPs as soon as they are available
 --]]
-Battle_NoblePhantasm = "danger" 
+Battle_NoblePhantasm = "disabled" 
 
 --Whenever there's additional event point reward window to be clicked through, isEvent = 1. Please check the details on github.
 isEvent = 1

--- a/FGO_EN_REGULAR.lua
+++ b/FGO_EN_REGULAR.lua
@@ -79,6 +79,14 @@ Autoskill_List[10] = ""
 --You can change card selection priority. For example, BAQ stands for: weak buster->buster->resist buster->weak arts->arts->resist arts->weak quick->quick->resist quick
 Battle_CardPriority = "BAQ"
 
+--[[
+Options:
+• disabled: will never cast NPs automatically, except for Autoskill commands
+• danger: will cast NPs only when there are DANGER or SERVANT enemies on screen
+• spam: will cast NPs as soon as they are available
+--]]
+Battle_NoblePhantasm = "danger" 
+
 --Whenever there's additional event point reward window to be clicked through, isEvent = 1. Please check the details on github.
 isEvent = 1
 

--- a/FGO_JP_REGULAR.lua
+++ b/FGO_JP_REGULAR.lua
@@ -85,7 +85,7 @@ Options:
 • danger: will cast NPs only when there are DANGER or SERVANT enemies on screen
 • spam: will cast NPs as soon as they are available
 --]]
-Battle_NoblePhantasm = "danger" 
+Battle_NoblePhantasm = "disabled" 
 
 --イベントステージ終了時にて別枠がある場合（もう一つのポイント報酬ウィンドウとか、詳細はウェブのreadmeで）
 isEvent = 0

--- a/FGO_JP_REGULAR.lua
+++ b/FGO_JP_REGULAR.lua
@@ -79,6 +79,14 @@ Autoskill_List[10] = ""
 --カード選択の優先順位。BAQの場合はweak buster->buster->resist buster->weak arts->arts->resist arts->weak quick->quick->resist quick
 Battle_CardPriority = "BAQ"
 
+--[[
+Options:
+• disabled: will never cast NPs automatically, except for Autoskill commands
+• danger: will cast NPs only when there are DANGER or SERVANT enemies on screen
+• spam: will cast NPs as soon as they are available
+--]]
+Battle_NoblePhantasm = "danger" 
+
 --イベントステージ終了時にて別枠がある場合（もう一つのポイント報酬ウィンドウとか、詳細はウェブのreadmeで）
 isEvent = 0
 

--- a/FGO_TW_REGULAR.lua
+++ b/FGO_TW_REGULAR.lua
@@ -83,7 +83,7 @@ Options:
 • danger: will cast NPs only when there are DANGER or SERVANT enemies on screen
 • spam: will cast NPs as soon as they are available
 --]]
-Battle_NoblePhantasm = "danger" 
+Battle_NoblePhantasm = "disabled" 
 
 --若活動有另外的獎勵視窗需點選，isEvent = 1。 詳細請見github上的readme
 isEvent = 0

--- a/FGO_TW_REGULAR.lua
+++ b/FGO_TW_REGULAR.lua
@@ -77,6 +77,14 @@ Autoskill_List[10] = ""
 --可以用這個選項組藍卡隊了安安。這個選項會影響卡片選擇優先順位，例：BAQ代表weak buster->buster->resist buster->weak arts->arts->resist arts->weak quick->quick->resist quick
 Battle_CardPriority = "BAQ"
 
+--[[
+Options:
+• disabled: will never cast NPs automatically, except for Autoskill commands
+• danger: will cast NPs only when there are DANGER or SERVANT enemies on screen
+• spam: will cast NPs as soon as they are available
+--]]
+Battle_NoblePhantasm = "danger" 
+
 --若活動有另外的獎勵視窗需點選，isEvent = 1。 詳細請見github上的readme
 isEvent = 0
 

--- a/regular.lua
+++ b/regular.lua
@@ -251,8 +251,8 @@ function battle()
     	wait(1)
 	end
     
-    if TargetChoosen == 1 and decodeSkill_NPCasting == 0 then
-        --ultcard()
+    if Battle_NoblePhantasm == "spam" or (Battle_NoblePhantasm == "danger" and TargetChoosen == 1) then
+        ultcard()
     end
 
     wait(0.5)


### PR DESCRIPTION
In an attempt to solve #67, I added this new option `Battle_NoblePhantasm`.

Possible values are:
• `disabled`: will never cast NPs automatically, except for Autoskill commands (default)
• `danger`: will cast NPs only when there are DANGER or SERVANT enemies on screen (old)
• `spam`: will cast NPs as soon as they are available (new!)