### PR TITLE
fix: Autoskill_List doesn't work

### DIFF
--- a/regular.lua
+++ b/regular.lua
@@ -203,6 +203,9 @@ end
 
 function init()
 	--Set only ONCE for every separated script run.
+	PSADialogueShown = 0
+	PSADialogue()
+
 	autoskill.init(battle, card)
 	battle.init(autoskill, card)
 	card.init(autoskill, battle)
@@ -212,8 +215,6 @@ function init()
 	Settings:setScriptDimension(true,2560)
 
 	StoneUsed = 0
-	PSADialogueShown = 0
-	PSADialogue()
 end
 
 init()


### PR DESCRIPTION
Bug: init Autoskill_List commands after insert command table,
thus autoskill always use Skill_Command.

By the way, I think Skill_Command can be replaced by Autoskill_List.
It's a bit strange to have two similar skill system.