### PR TITLE
Added function for JP Stamina Refill

### DIFF
--- a/regular.lua
+++ b/regular.lua
@@ -62,9 +62,12 @@ function menu()
 
 	--Auto refill.
 	if StaminaRegion:exists(GeneralImagePath .. "stamina.png", 0) then
-		RefillStamina()
+		if GameRegion == "EN" then
+			RefillStamina()
+		else
+			RefillJP()
+		end
 	end
-
 	--Friend selection.
 	local hasSelectedSupport = support.selectSupport(Support_SelectionMode)
 	if hasSelectedSupport then
@@ -112,6 +115,13 @@ function RefillStamina()
 	else
 		scriptExit("AP ran out!")
 	end
+end
+
+function RefillJP()
+	-- Refill Stamina until stamina.png isn't on screen
+	repeat
+		RefillStamina()
+	until not StaminaRegion:exists(GeneralImagePath .. "stamina.png", 0)
 end
 
 function startQuest()

--- a/regular.lua
+++ b/regular.lua
@@ -218,6 +218,8 @@ function init()
 	setImmersiveMode(true)
 	Settings:setCompareDimension(true,1280)
 	Settings:setScriptDimension(true,2560)
+	
+	toast("Will only select servant/danger enemy as noble phantasm target, unless specified using Skill Command. Please check github for further detail.")
 
 	StoneUsed = 0
 	PSADialogue()
@@ -231,7 +233,6 @@ end
 init()
 while(1) do
 	if MenuRegion:exists(GeneralImagePath .. "menu.png", 0) then
-		toast("Will only select servant/danger enemy as noble phantasm target, unless specified using Skill Command. Please check github for further detail.")
 		menu()
 	end
 	if battle.isIdle() then

--- a/regular.lua
+++ b/regular.lua
@@ -61,12 +61,8 @@ function menu()
 	wait(1.5)
 
 	--Auto refill.
-	if StaminaRegion:exists(GeneralImagePath .. "stamina.png", 0) then
-		if GameRegion == "EN" then
-			RefillStamina()
-		else
-			RefillJP()
-		end
+	while StaminaRegion:exists(GeneralImagePath .. "stamina.png", 0) do
+		RefillStamina()
 	end
 	--Friend selection.
 	local hasSelectedSupport = support.selectSupport(Support_SelectionMode)
@@ -115,13 +111,6 @@ function RefillStamina()
 	else
 		scriptExit("AP ran out!")
 	end
-end
-
-function RefillJP()
-	-- Refill Stamina until stamina.png isn't on screen
-	repeat
-		RefillStamina()
-	until not StaminaRegion:exists(GeneralImagePath .. "stamina.png", 0)
 end
 
 function startQuest()


### PR DESCRIPTION
Added a function that checks the region before entering refill stamina. In the instance it is true, stamina will be refilled as before, if not it will refill till the stamina image no longer exists on screen.

Needs to be checked in other regions to ensure whether it is needed for those as well. At the point of this original commit, it will only apply to EN as it is the only one I'm aware of that it would not be needed.