### PR TITLE
Try to fix GameRegion specific issue(target selection behavior in JP server)

### DIFF
--- a/modules/battle.lua
+++ b/modules/battle.lua
@@ -175,6 +175,10 @@ end
 
 chooseTarget = function(targetIndex)
 	click(TARGET_CLICK_ARRAY[targetIndex])
+	if GameRegion = "JP" then
+		click(TARGET_CLICK_ARRAY[targetIndex])
+		--Click again to close extra window. See https://github.com/29988122/Fate-Grand-Order_Lua/issues/109
+	end
 	onTargetChosen()
 end
 


### PR DESCRIPTION
https://github.com/29988122/Fate-Grand-Order_Lua/issues/109
Refer to the latest comment to see the target selection behavior video.
The way to reproduce this bug was written in the first post of the issue.

It was long click before, but now it's only a single click. Damn annoying.

***

Apparently this needs your input.

1. I don't know how Lua transfer values inside<->outside functions, or modules. This GameRegion variable is from FGO_**_REGULAR.lua, so I have no idea it will work or not. 

2. More importantly, I have no idea if this is the right way to do abstraction - we'll have to achieve low coupling(software engineering) since this is the main purpose of the refactoring, right?

*(We have this, and a fair bit of region specific behavior being added frequently(filtering UI, button element position change, to name a few.), which at first implemented in JP server, but will probably be online in other servers within a year.)*

How do we handle these from now on?