### PR TITLE
Add updating click for select first method on select support screen.

### DIFF
--- a/modules/support.lua
+++ b/modules/support.lua
@@ -84,6 +84,16 @@ end
 
 selectFirst = function()
 	click(game.SUPPORT_FIRST_SUPPORT_CLICK)
+	while game.SUPPORT_SCREEN_REGION:exists(GeneralImagePath .. "support_screen.png")
+	do
+		wait(10)
+		click(game.SUPPORT_UPDATE_CLICK)
+		wait(1)
+		click(game.SUPPORT_UPDATE_YES_CLICK)
+		wait(3)
+		click(game.SUPPORT_FIRST_SUPPORT_CLICK)
+		wait(1)
+	end
 	return true
 end
 


### PR DESCRIPTION
For current JP server, if user filter out 5* MLB event CE and use select first method,
it may not show any support and stuck at the support screen.