### PR TITLE
added Skill_Confirmation == 1 check to OrderChange()

### DIFF
--- a/modules/autoskill.lua
+++ b/modules/autoskill.lua
@@ -76,6 +76,9 @@ local function BeginOrderChange()
 	return function()
 		OpenMasterSkillMenu()
 		click(game.BATTLE_MASTER_SKILL_3_CLICK)
+		if Skill_Confirmation == 1 then
+			click(game.BATTLE_SKILL_OK_CLICK)
+		end
 		wait(0.3)
 
 		ChangeArray(STARTING_MEMBER_FUNCTION_ARRAY)


### PR DESCRIPTION
fixed bug with script that fails to do an order change without clicking OK on Skill Confirmation if user has that option enabled.