### PR TITLE
Adding slight functionality and adapting to new UI

### DIFF
--- a/FGO_CN_REGULAR.lua
+++ b/FGO_CN_REGULAR.lua
@@ -33,6 +33,13 @@ Support_FriendsOnly = 0
 Support_PreferredServants = "waver4.png, waver3.png, waver2.png, waver1.png"
 Support_PreferredCEs = "*chaldea_lunchtime.png"
 
+--Bond CE Get
+StopAfterBond10 = 0--[[
+	This option is switched to 1 if you want to stop the script after retreiving a Bond 10 CE card
+
+	TODO: move this explanation to documentation
+--]]
+
 --BoostItem
 BoostItem_SelectionMode = "disabled" --[[
 	possible values: disabled, 1, 2 or 3

--- a/FGO_EN_REGULAR.lua
+++ b/FGO_EN_REGULAR.lua
@@ -33,6 +33,13 @@ Support_FriendsOnly = 0
 Support_PreferredServants = "waver4.png, waver3.png, waver2.png, waver1.png"
 Support_PreferredCEs = "*chaldea_lunchtime.png"
 
+--Bond CE Get
+StopAfterBond10 = 0--[[
+	This option is switched to 1 if you want to stop the script after retreiving a Bond 10 CE card
+
+	TODO: move this explanation to documentation
+--]]
+
 --BoostItem
 BoostItem_SelectionMode = "disabled" --[[
 	possible values: disabled, 1, 2 or 3

--- a/FGO_JP_REGULAR.lua
+++ b/FGO_JP_REGULAR.lua
@@ -33,6 +33,12 @@ Support_FriendsOnly = 0
 Support_PreferredServants = "waver4.png, waver3.png, waver2.png, waver1.png"
 Support_PreferredCEs = "*chaldea_lunchtime.png"
 
+--Bond CE Get
+StopAfterBond10 = 0--[[
+	This option is switched to 1 if you want to stop the script after retreiving a Bond 10 CE card
+	TODO: move this explanation to documentation
+--]]
+
 --BoostItem
 BoostItem_SelectionMode = "disabled" --[[
 	possible values: disabled, 1, 2 or 3

--- a/FGO_TW_REGULAR.lua
+++ b/FGO_TW_REGULAR.lua
@@ -33,6 +33,12 @@ Support_FriendsOnly = 0
 Support_PreferredServants = "waver4.png, waver3.png, waver2.png, waver1.png"
 Support_PreferredCEs = "*chaldea_lunchtime.png"
 
+--Bond CE Get
+StopAfterBond10 = 0--[[
+	This option is switched to 1 if you want to stop the script after retreiving a Bond 10 CE card
+	TODO: move this explanation to documentation
+--]]
+
 --BoostItem
 BoostItem_SelectionMode = "disabled" --[[
 	possible values: disabled, 1, 2 or 3

--- a/modules/game.lua
+++ b/modules/game.lua
@@ -44,6 +44,7 @@ game.SUPPORT_UPDATE_CLICK = Location(1670,250)
 game.SUPPORT_UPDATE_YES_CLICK = Location(1480,1110)
 game.SUPPORT_LIST_TOP_CLICK = Location(2480,360)
 game.SUPPORT_FIRST_SUPPORT_CLICK = Location(1900,500)
+game.CONTINUE_CLICK = Location(1650,1120)
 
 game.BATTLE_SCREEN_REGION = Region(2105,1259,336,116) -- see docs/battle_region.png
 game.BATTLE_STAGE_COUNT_REGION = StageCountRegion -- this is provided by the config file

--- a/modules/game.lua
+++ b/modules/game.lua
@@ -1,8 +1,10 @@
 local game = {}
 
 game.MENU_SCREEN_REGION = Region(2100,1200,1000,1000)
+game.CONTINUE_REGION = Region(1400,1000,600,200)
 game.MENU_SELECT_QUEST_CLICK = Location(1900,400)
 game.MENU_START_QUEST_CLICK = Location(2400,1350)
+game.CONTINUE_CLICK = Location(1650,1120)
 
 -- see docs/menu_boost_item_click_array.png
 game.MENU_BOOST_ITEM_1_CLICK = Location(1280,418)
@@ -44,7 +46,6 @@ game.SUPPORT_UPDATE_CLICK = Location(1670,250)
 game.SUPPORT_UPDATE_YES_CLICK = Location(1480,1110)
 game.SUPPORT_LIST_TOP_CLICK = Location(2480,360)
 game.SUPPORT_FIRST_SUPPORT_CLICK = Location(1900,500)
-game.CONTINUE_CLICK = Location(1650,1120)
 
 game.BATTLE_SCREEN_REGION = Region(2105,1259,336,116) -- see docs/battle_region.png
 game.BATTLE_STAGE_COUNT_REGION = StageCountRegion -- this is provided by the config file

--- a/regular.lua
+++ b/regular.lua
@@ -101,23 +101,7 @@ end
 
 local function Result()
 	--Validator document https://github.com/29988122/Fate-Grand-Order_Lua/wiki/In-Game-Result-Screen-Flow for detail.
-	continueClick(game.RESULT_NEXT_CLICK,45)
-        
-        if Region(1400,1000,600,200):exists(GeneralImagePath .. "confirm.png") then
-                IsContinuing = 1
-                click(game.STAMINA_OK_CLICK)
-                battle.resetState()
-	        turnCounter = {0, 0, 0, 0, 0}
-
-
-                wait(1.5)
-
-                --Auto refill.
-	        while game.STAMINA_SCREEN_REGION:exists(GeneralImagePath .. "stamina.png") do
-	   	        RefillStamina()
-	        end
-        else
-
+	continueClick(game.RESULT_NEXT_CLICK,35)
 
 	wait(5)
 
@@ -125,27 +109,45 @@ local function Result()
 		click(game.RESULT_CE_REWARD_CLOSE_CLICK)
 		continueClick(game.RESULT_NEXT_CLICK,35) --Still need to proceed through reward screen.
 	end
+	
+	
+	if Region(1400,1000,600,200):exists(GeneralImagePath .. "confirm.png") then
+		IsContinuing = 1 -- Needed to show we don't need to enter the "StartQuest" function
+		
+		-- Pressing Continue option after completing a quest, reseting the state as would occur in "Menu" function
+		click(game.CONTINUE_CLICK)
+		battle.resetState()
+		turnCounter = {0, 0, 0, 0, 0}
+		
+		wait(1.5)
+		
+		--If Stamina is empty, follow same protocol as is in "Menu" function
+                --Auto refill.
+		while game.STAMINA_SCREEN_REGION:exists(GeneralImagePath .. "stamina.png") do
+			RefillStamina()
+		end
+	else
 
-	--Friend request dialogue. Appears when non-friend support was selected this battle.  Ofc it's defaulted not sending request.
-	if game.RESULT_FRIEND_REQUEST_REGION:exists(GeneralImagePath .. "friendrequest.png") ~= nil then
-		click(game.RESULT_FRIEND_REQUEST_REJECT_CLICK)
+		--Friend request dialogue. Appears when non-friend support was selected this battle.  Ofc it's defaulted not sending request.
+		if game.RESULT_FRIEND_REQUEST_REGION:exists(GeneralImagePath .. "friendrequest.png") ~= nil then
+			click(game.RESULT_FRIEND_REQUEST_REJECT_CLICK)
+		end
+
+		wait(15)
+
+		if game.RESULT_CE_REWARD_REGION:exists(GeneralImagePath .. "ce_reward.png") ~= nil then
+			click(game.RESULT_CE_REWARD_CLOSE_CLICK)
+			wait(1)
+			click(game.RESULT_CE_REWARD_CLOSE_CLICK)
+		end
+
+		wait(5)
+
+		--1st time quest reward screen.
+		if game.RESULT_QUEST_REWARD_REGION:exists(GeneralImagePath .. "questreward.png") ~= nil then
+			click(game.RESULT_NEXT_CLICK)
+		end
 	end
-
-	wait(15)
-
-	if game.RESULT_CE_REWARD_REGION:exists(GeneralImagePath .. "ce_reward.png") ~= nil then
-		click(game.RESULT_CE_REWARD_CLOSE_CLICK)
-		wait(1)
-		click(game.RESULT_CE_REWARD_CLOSE_CLICK)
-	end
-
-	wait(5)
-
-	--1st time quest reward screen.
-	if game.RESULT_QUEST_REWARD_REGION:exists(GeneralImagePath .. "questreward.png") ~= nil then
-		click(game.RESULT_NEXT_CLICK)
-	end
-        end
 end
 
 local function IsInSupport()

--- a/regular.lua
+++ b/regular.lua
@@ -22,6 +22,7 @@ local autoskill = require("autoskill")
 
 -- fields
 local StoneUsed = 0
+local IsContinuing = 0
 
 -- functions
 local function RefillStamina()
@@ -103,6 +104,7 @@ local function Result()
 	continueClick(game.RESULT_NEXT_CLICK,45)
         
         if Region(1400,1000,600,200):exists(GeneralImagePath .. "confirm.png") then
+                IsContinuing = 1
                 click(game.STAMINA_OK_CLICK)
                 battle.resetState()
 	        turnCounter = {0, 0, 0, 0, 0}
@@ -155,6 +157,10 @@ local function Support()
 	--Friend selection.
 	local hasSelectedSupport = support.selectSupport(Support_SelectionMode)
 	if hasSelectedSupport then
+                if IsContinuing then
+                        wait(2.5)
+                        StartQuest()
+                end
 	end
 
 end

--- a/regular.lua
+++ b/regular.lua
@@ -106,6 +106,9 @@ local function Result()
 	wait(5)
 
 	if game.RESULT_CE_REWARD_REGION:exists(GeneralImagePath .. "ce_reward.png") ~= nil then
+		if StopAfterBond10 then
+			scriptExit("Bond 10 CE GET!")
+		end
 		click(game.RESULT_CE_REWARD_CLOSE_CLICK)
 		continueClick(game.RESULT_NEXT_CLICK,35) --Still need to proceed through reward screen.
 	end

--- a/regular.lua
+++ b/regular.lua
@@ -155,8 +155,6 @@ local function Support()
 	--Friend selection.
 	local hasSelectedSupport = support.selectSupport(Support_SelectionMode)
 	if hasSelectedSupport then
-		wait(2.5)
-		StartQuest()
 	end
 
 end

--- a/regular.lua
+++ b/regular.lua
@@ -92,13 +92,6 @@ local function Menu()
 	while game.STAMINA_SCREEN_REGION:exists(GeneralImagePath .. "stamina.png") do
 		RefillStamina()
 	end
-	
-	--Friend selection.
-	local hasSelectedSupport = support.selectSupport(Support_SelectionMode)
-	if hasSelectedSupport then
-		wait(2.5)
-		StartQuest()
-	end
 end
 
 local function IsInResult()
@@ -108,22 +101,33 @@ end
 local function Result()
 	--Validator document https://github.com/29988122/Fate-Grand-Order_Lua/wiki/In-Game-Result-Screen-Flow for detail.
 	continueClick(game.RESULT_NEXT_CLICK,45)
+        
+        if Region(1400,1000,600,200):exists(GeneralImagePath .. "confirm.png") then
+                click(AcceptClick)
+                wait(1.5)
+
+                --Auto refill.
+	        while game.STAMINA_SCREEN_REGION:exists(GeneralImagePath .. "stamina.png") do
+	   	        RefillStamina()
+	        end
+        else
+
 
 	wait(5)
 
-	if game.RESULT_CE_REWARD_REGION:exists(Pattern(GeneralImagePath .. "ce_reward.png")) ~= nil then
+	if game.RESULT_CE_REWARD_REGION:exists(GeneralImagePath .. "ce_reward.png") ~= nil then
 		click(game.RESULT_CE_REWARD_CLOSE_CLICK)
 		continueClick(game.RESULT_NEXT_CLICK,35) --Still need to proceed through reward screen.
 	end
 
 	--Friend request dialogue. Appears when non-friend support was selected this battle.  Ofc it's defaulted not sending request.
-	if game.RESULT_FRIEND_REQUEST_REGION:exists(Pattern(GeneralImagePath .. "friendrequest.png")) ~= nil then
+	if game.RESULT_FRIEND_REQUEST_REGION:exists(GeneralImagePath .. "friendrequest.png") ~= nil then
 		click(game.RESULT_FRIEND_REQUEST_REJECT_CLICK)
 	end
 
 	wait(15)
 
-	if game.RESULT_CE_REWARD_REGION:exists(Pattern(GeneralImagePath .. "ce_reward.png")) ~= nil then
+	if game.RESULT_CE_REWARD_REGION:exists(GeneralImagePath .. "ce_reward.png") ~= nil then
 		click(game.RESULT_CE_REWARD_CLOSE_CLICK)
 		wait(1)
 		click(game.RESULT_CE_REWARD_CLOSE_CLICK)
@@ -132,9 +136,25 @@ local function Result()
 	wait(5)
 
 	--1st time quest reward screen.
-	if game.RESULT_QUEST_REWARD_REGION:exists(Pattern(GeneralImagePath .. "questreward.png")) ~= nil then
+	if game.RESULT_QUEST_REWARD_REGION:exists(GeneralImagePath .. "questreward.png") ~= nil then
 		click(game.RESULT_NEXT_CLICK)
 	end
+        end
+end
+
+local function IsInSupport()
+        return game.SUPPORT_SCREEN_REGION:exists(GeneralImagePath .. "support_screen.png")
+end
+
+local function Support()
+
+	--Friend selection.
+	local hasSelectedSupport = support.selectSupport(Support_SelectionMode)
+	if hasSelectedSupport then
+		wait(2.5)
+		StartQuest()
+	end
+
 end
 
 --User option PSA dialogue. Also choosble list of perdefined skill.
@@ -213,7 +233,8 @@ end
 local SCREENS = {
 	{ Validator = battle.isIdle, Actor = battle.performBattle },
 	{ Validator = IsInMenu,      Actor = Menu },
-	{ Validator = IsInResult,    Actor = Result }
+	{ Validator = IsInResult,    Actor = Result},
+        { Validator = IsInSupport,   Actor = Support}
 }
 
 Init()

--- a/regular.lua
+++ b/regular.lua
@@ -103,7 +103,7 @@ local function Result()
 	continueClick(game.RESULT_NEXT_CLICK,45)
         
         if Region(1400,1000,600,200):exists(GeneralImagePath .. "confirm.png") then
-                click(AcceptClick)
+                click(game.STAMINA_OK_CLICK)
                 wait(1.5)
 
                 --Auto refill.

--- a/regular.lua
+++ b/regular.lua
@@ -114,7 +114,7 @@ local function Result()
 	end
 	
 	
-	if Region(1400,1000,600,200):exists(GeneralImagePath .. "confirm.png") then
+	if game.CONTINUE_REGION:exists(GeneralImagePath .. "confirm.png") then
 		IsContinuing = 1 -- Needed to show we don't need to enter the "StartQuest" function
 		
 		-- Pressing Continue option after completing a quest, reseting the state as would occur in "Menu" function

--- a/regular.lua
+++ b/regular.lua
@@ -104,6 +104,10 @@ local function Result()
         
         if Region(1400,1000,600,200):exists(GeneralImagePath .. "confirm.png") then
                 click(game.STAMINA_OK_CLICK)
+                battle.resetState()
+	        turnCounter = {0, 0, 0, 0, 0}
+
+
                 wait(1.5)
 
                 --Auto refill.

--- a/regular.lua
+++ b/regular.lua
@@ -106,9 +106,13 @@ local function Result()
 	wait(5)
 
 	if game.RESULT_CE_REWARD_REGION:exists(GeneralImagePath .. "ce_reward.png") ~= nil then
-		if StopAfterBond10 then
-			scriptExit("Bond 10 CE GET!")
+		
+		if StopAfterBond10 ~= nil then --Making sure they can still run it without updating FGO_XX_REGULAR files
+			if StopAfterBond10 then
+				scriptExit("Bond 10 CE GET!")
+			end
 		end
+		
 		click(game.RESULT_CE_REWARD_CLOSE_CLICK)
 		continueClick(game.RESULT_NEXT_CLICK,35) --Still need to proceed through reward screen.
 	end


### PR DESCRIPTION
This Pull targets the new UI implemented in JP server (and eventually all others) without limited current servers and making them automatically support the new system.

Also added functionality to automatically stop after receiving a Bond 10 CE, allowing them to change Servants if they so choose. This option is a toggle located in the FGO_XX_REGULAR files.