### PR TITLE
Friend Specification for Support

### DIFF
--- a/FGO_CN_REGULAR.lua
+++ b/FGO_CN_REGULAR.lua
@@ -31,9 +31,9 @@ Support_SwipesPerUpdate = 10
 Support_MaxUpdates = 3
 Support_FallbackTo = "manual"
 Support_FriendsOnly = 0
+Support_FriendNames = ""
 Support_PreferredServants = "waver4.png, waver3.png, waver2.png, waver1.png"
 Support_PreferredCEs = "*chaldea_lunchtime.png"
-Support_FriendNames = ""
 
 --Bond CE Get
 StopAfterBond10 = 0--[[

--- a/FGO_CN_REGULAR.lua
+++ b/FGO_CN_REGULAR.lua
@@ -33,6 +33,7 @@ Support_FallbackTo = "manual"
 Support_FriendsOnly = 0
 Support_PreferredServants = "waver4.png, waver3.png, waver2.png, waver1.png"
 Support_PreferredCEs = "*chaldea_lunchtime.png"
+Support_FriendNames = ""
 
 --Bond CE Get
 StopAfterBond10 = 0--[[

--- a/FGO_EN_REGULAR.lua
+++ b/FGO_EN_REGULAR.lua
@@ -31,9 +31,9 @@ Support_SwipesPerUpdate = 10
 Support_MaxUpdates = 3
 Support_FallbackTo = "manual"
 Support_FriendsOnly = 0
+Support_FriendNames = ""
 Support_PreferredServants = "waver4.png, waver3.png, waver2.png, waver1.png"
 Support_PreferredCEs = "*chaldea_lunchtime.png"
-Support_FriendNames = ""
 
 --Bond CE Get
 StopAfterBond10 = 0--[[

--- a/FGO_EN_REGULAR.lua
+++ b/FGO_EN_REGULAR.lua
@@ -33,6 +33,7 @@ Support_FallbackTo = "manual"
 Support_FriendsOnly = 0
 Support_PreferredServants = "waver4.png, waver3.png, waver2.png, waver1.png"
 Support_PreferredCEs = "*chaldea_lunchtime.png"
+Support_FriendNames = ""
 
 --Bond CE Get
 StopAfterBond10 = 0--[[

--- a/FGO_JP_REGULAR.lua
+++ b/FGO_JP_REGULAR.lua
@@ -31,9 +31,9 @@ Support_SwipesPerUpdate = 10
 Support_MaxUpdates = 3
 Support_FallbackTo = "manual"
 Support_FriendsOnly = 0
+Support_FriendNames = ""
 Support_PreferredServants = "waver4.png, waver3.png, waver2.png, waver1.png"
 Support_PreferredCEs = "*chaldea_lunchtime.png"
-Support_FriendNames = ""
 
 --Bond CE Get
 StopAfterBond10 = 0--[[

--- a/FGO_JP_REGULAR.lua
+++ b/FGO_JP_REGULAR.lua
@@ -33,6 +33,7 @@ Support_FallbackTo = "manual"
 Support_FriendsOnly = 0
 Support_PreferredServants = "waver4.png, waver3.png, waver2.png, waver1.png"
 Support_PreferredCEs = "*chaldea_lunchtime.png"
+Support_FriendNames = ""
 
 --Bond CE Get
 StopAfterBond10 = 0--[[

--- a/FGO_TW_REGULAR.lua
+++ b/FGO_TW_REGULAR.lua
@@ -31,9 +31,9 @@ Support_SwipesPerUpdate = 10
 Support_MaxUpdates = 3
 Support_FallbackTo = "manual"
 Support_FriendsOnly = 0
+Support_FriendNames = ""
 Support_PreferredServants = "waver4.png, waver3.png, waver2.png, waver1.png"
 Support_PreferredCEs = "*chaldea_lunchtime.png"
-Support_FriendNames = ""
 
 --Bond CE Get
 StopAfterBond10 = 0--[[

--- a/FGO_TW_REGULAR.lua
+++ b/FGO_TW_REGULAR.lua
@@ -33,6 +33,7 @@ Support_FallbackTo = "manual"
 Support_FriendsOnly = 0
 Support_PreferredServants = "waver4.png, waver3.png, waver2.png, waver1.png"
 Support_PreferredCEs = "*chaldea_lunchtime.png"
+Support_FriendNames = ""
 
 --Bond CE Get
 StopAfterBond10 = 0--[[

--- a/modules/game.lua
+++ b/modules/game.lua
@@ -31,6 +31,7 @@ game.STAMINA_BRONZE_CLICK = Location(1270,1140)
 game.SUPPORT_SCREEN_REGION = Region(0,0,110,332)
 game.SUPPORT_LIST_REGION = Region(70,332,378,1091) -- see docs/support_list_region.png
 game.SUPPORT_SWIPE_START_CLICK = Location(35,1190)
+game.SUPPORT_FRIENDS_REGION = Region(448,332,1210,1091)
 game.SUPPORT_SWIPE_END_CLICK = SupportSwipeEndClick -- this is provided by the config file
 
 game.SUPPORT_LIST_ITEM_REGION_ARRAY = {

--- a/modules/support.lua
+++ b/modules/support.lua
@@ -79,6 +79,9 @@ selectSupport = function(selectionMode)
 
 		elseif selectionMode == "manual" then
 			selectManual()
+		
+		elseif selectionMode == "friend" then
+			return selectFriend()
 
 		elseif selectionMode == "preferred" then
 			local searchMethod = decideSearchMethod()
@@ -112,6 +115,14 @@ end
 
 selectManual = function()
 	scriptExit("Support selection mode set to \"manual\".")
+end
+
+selectFriend = function()
+	if #FriendNameArray > 0 then
+		return selectPreferred(searchMethod.byFriendName)
+	end
+	
+	scriptExit("When using \"friend\" support selection mode, specify at least one friend name.")
 end
 
 selectPreferred = function(searchMethod)
@@ -189,14 +200,10 @@ searchVisible = function(searchMethod)
 end
 
 decideSearchMethod = function()
-	local hasFriendNames = #FriendNameArray > 0
 	local hasServants = #PreferredServantArray > 0
 	local hasCraftEssences = #PreferredCraftEssenceTable > 0
 
-	if hasFriendNames then
-		return searchMethod.byFriendName
-
-	elseif hasServants and hasCraftEssences then
+	if hasServants and hasCraftEssences then
 		return searchMethod.byServantAndCraftEssence
 
 	elseif hasServants then
@@ -206,7 +213,7 @@ decideSearchMethod = function()
 		return searchMethod.byCraftEssence
 
 	else
-		scriptExit("When using \"preferred\" support selection mode, specify at least one friend's name, a Servant or a Craft Essence.")
+		scriptExit("When using \"preferred\" support selection mode, specify at least one Servant or Craft Essence.")
 	end
 end
 

--- a/modules/support.lua
+++ b/modules/support.lua
@@ -151,16 +151,18 @@ selectPreferred = function(searchMethod)
 	end
 end
 
+
 selectFriend = function()
 	local numberOfSwipes = 0
 	local numberOfUpdates = 0
 	
 	while(true)
 	do
-		if findFriendName then
-			click( match:getTarget() )
+		local result, support = searchFriends()
+		if result == "ok" then
+			click( support )
 			
-		elseif numberOfSwipes < Support_SwipesPerUpdate then
+		elseif result == "not-found" and numberOfSwipes < Support_SwipesPerUpdate then
 			scrollList()
 			numberOfSwipes = numberOfSwipes + 1
 			wait(0.3)
@@ -316,13 +318,35 @@ isLimitBroken = function(craftEssence)
 	return limitBreakRegion:exists(limitBreakPattern)
 end
 
+searchFriends = function()
+		local function performSearch()
+		
+		if not isFriend(game.SUPPORT_FRIEND_REGION) then
+			return {"no-friends-at-all"} -- no friends on screen, so there's no point in scrolling anymore
+		end
+
+		local support = findFriendName()
+		if support == nil then
+			return {"not-found"} -- nope, not found this time. keep scrolling
+		end
+
+		return {"ok", support}
+	end
+
+	-- see https://www.lua.org/pil/5.1.html for details on "unpack"
+	return unpack(ankuluaUtils.UseSameSnapIn(performSearch))
+end
+
 findFriendName = function()
-	for _, friend in ipairs(friend) do
-			if game.SUPPORT_FRIENDS_REGION:exists(GeneralImagePath .. friend) then
-				return true
-			end
+	local friends = {}
+
+	for _, friendName in ipairs(FriendNameArray) do
+		for _, theFriend in ipairs(regionFindAllNoFindException(game.SUPPORT_FRIENDS_REGION, Pattern(SupportImagePath .. friendName))) do
+			table.insert(friends, theFriend)
 		end
 	end
+
+	return friends[1]
 end
 
 -- "public" interface

--- a/modules/support.lua
+++ b/modules/support.lua
@@ -161,6 +161,7 @@ selectFriend = function()
 		local result, support = searchFriends()
 		if result == "ok" then
 			click( support )
+			return true
 			
 		elseif result == "not-found" and numberOfSwipes < Support_SwipesPerUpdate then
 			scrollList()

--- a/modules/support.lua
+++ b/modules/support.lua
@@ -11,6 +11,7 @@ local LimitBrokenCharacter = "*"
 -- state vars
 local PreferredServantArray = {}
 local PreferredCraftEssenceTable = {}
+local FriendNameArray = {}
 
 -- functions
 local init
@@ -18,6 +19,7 @@ local selectSupport
 local selectFirst
 local selectManual
 local selectPreferred
+local selectFriend
 local scrollList
 local searchVisible
 local decideSearchMethod
@@ -61,6 +63,12 @@ init = function()
 
 		table.insert(PreferredCraftEssenceTable, craftEssenceEntry)
 	end
+	
+	-- friends
+	for _, friend in ipairs(split(Support_FriendNames)) do
+		friend = stringUtils.Trim(friend)
+		table.insert(FriendNameArray, friend)
+	end
 end
 
 selectSupport = function(selectionMode)
@@ -75,6 +83,8 @@ selectSupport = function(selectionMode)
 			local searchMethod = decideSearchMethod()
 			return selectPreferred(searchMethod)
 
+		elseif selectionMode =="friend" then
+			return selectFriend()
 		else
 			scriptExit("Invalid support selection mode: \"" + selectionMode + "\".")
 		end
@@ -135,6 +145,39 @@ selectPreferred = function(searchMethod)
 			numberOfSwipes = 0
 
 		else -- okay, we have run out of options, let's give up
+			click(game.SUPPORT_LIST_TOP_CLICK)
+			return selectSupport(Support_FallbackTo)
+		end
+	end
+end
+
+selectFriend = function()
+	local numberOfSwipes = 0
+	local numberOfUpdates = 0
+	
+	while(true)
+	do
+		if findFriendName then
+			click( match:getTarget() )
+			
+		elseif numberOfSwipes < Support_SwipesPerUpdate then
+			scrollList()
+			numberOfSwipes = numberOfSwipes + 1
+			wait(0.3)
+	
+		elseif numberOfUpdates < Support_MaxUpdates then
+			toast("Support list will be updated in 3 seconds.")
+			wait(3)
+			
+			click(game.SUPPORT_UPDATE_CLICK)
+			wait(1)
+			click(game.SUPPORT_UPDATE_YES_CLICK)
+			wait(3)
+
+			numberOfUpdates = numberOfUpdates + 1
+			numberOfSwipes = 0
+			
+		else
 			click(game.SUPPORT_LIST_TOP_CLICK)
 			return selectSupport(Support_FallbackTo)
 		end
@@ -271,6 +314,15 @@ isLimitBroken = function(craftEssence)
 	local limitBreakPattern = Pattern(GeneralImagePath .. "limitBroken.png"):similar(0.8)
 
 	return limitBreakRegion:exists(limitBreakPattern)
+end
+
+findFriendName = function()
+	for _, friend in ipairs(friend) do
+			if game.SUPPORT_FRIENDS_REGION:exists(GeneralImagePath .. friend) then
+				return true
+			end
+		end
+	end
 end
 
 -- "public" interface


### PR DESCRIPTION
As requested by someone, I put together a new feature for Support selection. With this, people can make a picture of a friends name on their support list and use that to find said friend instead of a specific support. They will need to ensure they are in the right class selection though, to make sure they are granted the right support they expect.

With this, the Support selection process doesn't change for the most part. There is a new option in the FGO_XX_REGULAR.lua files for listing the names of the friend images they make, just like how you list the Servants/CEs you are looking for. You will use "friend" word instead of "preferred", "first", or "manual".

I used the same process used for the preferred option, just taking out some unneeded case handling since there are no instances of needing to match CEs or anything.with the names. I have tested to make sure it works as intended in NA server, should be fine in the others as well. I have to adjust the readme still, but that shouldn't be difficult. The original request is in #212 along with an example of what screenshotting the name looks like. I would like either a review of the changes or testing of them to ensure nothing seems out of place.

After this gets approved, I will begin work on a couple other features in preparation for the Lotto events coming in all the servers. The two I'm going to work on for a friend are selecting certain number of cards before NP and choosing targets between skills/turns. A friend needs these for his planned team for Nerofest on NA and I feel it would be useful for everyone if they have the option.