### PR TITLE
Targetable

### DIFF
--- a/modules/autoskill.lua
+++ b/modules/autoskill.lua
@@ -103,6 +103,17 @@ local function SelectSubMember(location)
 	end
 end
 
+local function SelectTarget()
+	ChangeArray(ENEMY_TARGET_ARRAY)
+end
+
+local function SelectEnemyTarget(location)
+	click(location)
+	click(game.BATTLE_EXTRAINFO_WINDOW_CLOSE_CLICK) -- Exit any extra menu
+	
+	ChangeArray(DEFAULT_FUNCTION_ARRAY)
+end
+
 DEFAULT_FUNCTION_ARRAY = {
 	["a"] = CastSkill(game.BATTLE_SKILL_1_CLICK),
 	["b"] = CastSkill(game.BATTLE_SKILL_2_CLICK),
@@ -117,6 +128,7 @@ DEFAULT_FUNCTION_ARRAY = {
 	["k"] = CastMasterSkill(game.BATTLE_MASTER_SKILL_2_CLICK),
 	["l"] = CastMasterSkill(game.BATTLE_MASTER_SKILL_3_CLICK),
 	["x"] = BeginOrderChange(),
+	["t"] = SelectTarget(),
 	["0"] = DoAbsolutelyNothing(),
 	["1"] = SelectSkillTarget(game.BATTLE_SERVANT_1_CLICK),
 	["2"] = SelectSkillTarget(game.BATTLE_SERVANT_2_CLICK),
@@ -138,6 +150,12 @@ SUB_MEMBER_FUNCTION_ARRAY = {
 	["3"] = SelectSubMember(game.BATTLE_SUB_MEMBER_3_CLICK)
 }
 
+ENEMY_TARGET_ARRAY = {
+	["1"] = SelectEnemyTarget(game.BATTLE_TARGET_CLICK_ARRAY[1]),
+	["2"] = SelectEnemyTarget(game.BATTLE_TARGET_CLICK_ARRAY[2]),
+	["3"] = SelectEnemyTarget(game.BATTLE_TARGET_CLICK_ARRAY[3])
+}
+
 -- other stuff
 local function InitCommands()
 	local stageCount = 1
@@ -148,7 +166,7 @@ local function InitCommands()
 				scriptExit("Error at '" .. commandList .. "': Skill Command cannot start with number '1', '2' and '3'!")
 			elseif string.match(commandList, "[%w+][#]") or string.match(commandList, "[#][%w+]") then
 				scriptExit("Error at '" .. commandList .. "': '#' must be preceded and followed by ','! Correct: ',#,' ")
-			elseif string.match(commandList, "[^a-l^1-6^#^x]") then
+			elseif string.match(commandList, "[^a-l^1-6^#^t^x]") then
 				scriptExit("Error at '" .. commandList .. "': Skill Command exceeded alphanumeric range! Expected 'x' or range 'a' to 'l' for alphabets and '0' to '6' for numbers.")
 			end
 		end

--- a/modules/autoskill.lua
+++ b/modules/autoskill.lua
@@ -104,12 +104,15 @@ local function SelectSubMember(location)
 end
 
 local function SelectTarget()
-	ChangeArray(ENEMY_TARGET_ARRAY)
+	return function()
+		ChangeArray(ENEMY_TARGET_ARRAY)
+	end
 end
 
 local function SelectEnemyTarget(location)
 	return function()
 		click(location)
+		wait(0.5)
 		click(game.BATTLE_EXTRAINFO_WINDOW_CLOSE_CLICK) -- Exit any extra menu
 	
 		ChangeArray(DEFAULT_FUNCTION_ARRAY)

--- a/modules/autoskill.lua
+++ b/modules/autoskill.lua
@@ -108,10 +108,12 @@ local function SelectTarget()
 end
 
 local function SelectEnemyTarget(location)
-	click(location)
-	click(game.BATTLE_EXTRAINFO_WINDOW_CLOSE_CLICK) -- Exit any extra menu
+	return function()
+		click(location)
+		click(game.BATTLE_EXTRAINFO_WINDOW_CLOSE_CLICK) -- Exit any extra menu
 	
-	ChangeArray(DEFAULT_FUNCTION_ARRAY)
+		ChangeArray(DEFAULT_FUNCTION_ARRAY)
+	end
 end
 
 DEFAULT_FUNCTION_ARRAY = {


### PR DESCRIPTION
I have added functionality to target specific enemies using autoskill. To do so, simply include 't' and a number to indicate which enemy you want to target. 1, 2, or 3. The format for enemy targets based on screen are:

t1    t2    t3

So an autoskill such as a2t3ht1i would use 1st skill on 2nd servant, target the far right enemy, use 8th skill, target far left enemy, use 9th skill.

This has already been tested by a few of my friends including myself and has been found to work on both NA and JP servers. Anyone who wishes to give it more tests, feel free. And if you could double check my logic, that would be great.

Another note, the auto target is still active, and won't be interfered with using this, but I believe we should make it set to 0 by default in order to avoid confusion or possible mishaps with the autoskill. Essentially, the script will assume you are using autoskill to target first, then if you decide you don't wish to, you can toggle auto target on for simpler autoskill command lists.