### PR TITLE
[minor enhancement] Display Amount of Apples used

### DIFF
--- a/regular.lua
+++ b/regular.lua
@@ -101,7 +101,7 @@ local function Menu()
 	battle.resetState()
 	turnCounter = {0, 0, 0, 0, 0}
 	-- Prints a message containing the amount of apple used
-	toast(StoneUsed)
+	toast(StoneUsed .. " refills used out of " .. Refill_Repetitions)
 
 	--Click uppermost quest.
 	click(game.MENU_SELECT_QUEST_CLICK)


### PR DESCRIPTION
After completing run, before clicking on next run ,displays the current amount of apple that was used in a toast.
Useful to users who leave their phones on and come back later to check how much apples they have already used.

Suggestive area to place the toast, if you want it after result ends, or before it even clicks on quest, modify as appropriate