### PR TITLE
Add AutoSupportSelection to AutoSkill list

### DIFF
--- a/FGO_REGULAR.lua
+++ b/FGO_REGULAR.lua
@@ -1,19 +1,4 @@
---Internal settings - do not modify.
---***************************************************************************
-dir = scriptPath()
-setImagePath(dir)
-
 Debug_Mode = false -- set to 'true' if needing to debug
-
---Initalize for user input listnames
-Autoskill_List = {}
-for i = 1, 10 do
-	Autoskill_List[i] = {}
-	for j = 1, 2 do
-		Autoskill_List[i][j] = 0
-	end
-end
---***************************************************************************
 
 -- Can be EN, JP, CN or TW
 GameRegion = "EN"
@@ -25,7 +10,7 @@ Refill_Enabled = 0
 Refill_Resource = "All Apples"
 Refill_Repetitions = 0
 
---AutoSupportSelection
+--AutoSupportSelection Defaults
 Support_SelectionMode = "first"
 Support_SwipesPerUpdate = 10
 Support_MaxUpdates = 3
@@ -56,40 +41,28 @@ StorySkip = 0 --[[
 --AutoSkill
 Enable_Autoskill = 0
 Skill_Confirmation = 0
-Skill_Command = "abc,#,def,#,ghi"
 
---AutoSkillList
-Enable_Autoskill_List = 0
-
-Autoskill_List[1][1] = "Settings No.1"
-Autoskill_List[1][2] = "abc,#,def,#,ghi"
-
-Autoskill_List[2][1] = "Settings No.2"
-Autoskill_List[2][2] = ""
-
-Autoskill_List[3][1] = "Settings No.3"
-Autoskill_List[3][2] = ""
-
-Autoskill_List[4][1] = "Settings No.4"
-Autoskill_List[4][2] = ""
-
-Autoskill_List[5][1] = "Settings No.5"
-Autoskill_List[5][2] = ""
-
-Autoskill_List[6][1] = "Settings No.6"
-Autoskill_List[6][2] = ""
-
-Autoskill_List[7][1] = "Settings No.7"
-Autoskill_List[7][2] = ""
-
-Autoskill_List[8][1] = "Settings No.8"
-Autoskill_List[8][2] = ""
-
-Autoskill_List[9][1] = "Settings No.9"
-Autoskill_List[9][2] = ""
-
-Autoskill_List[10][1] = "Settings No.10"
-Autoskill_List[10][2] = ""
+Autoskill_List =
+{
+	{
+		Name = "QP",
+		Skill_Command = "4,#,f5,#,i6",
+		Support_SelectionMode = "preferred",
+		Support_PreferredServants = "",
+		Support_PreferredCEs = "*mona_lisa.png"
+	},
+	{
+		Name = "Dust",
+		Skill_Command = "cdg5,#,e5,#,abi1k14",
+		Support_SelectionMode = "preferred",
+		Support_PreferredServants = "merlin1.png, merlin23.png, merlin4.png, merlin_c.png"
+	},
+	{
+		Name = "Gear",
+		Skill_Command = "6,#,h6,#,bx31fed1gj46",
+		Support_SelectionMode = "preferred"
+	}
+}
 
 --Card Priority Customization
 Battle_CardPriority = "BAQ"
@@ -100,4 +73,6 @@ Battle_NoblePhantasm = "disabled"
 --FastSkipDeadAnimation
 UnstableFastSkipDeadAnimation = 0
 
-dofile(dir .. "regular.lua")
+-- Do not modify below this line
+dir = scriptPath()
+dofile(dir .. "middleware.lua")

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Any of the questions can be asked in the "Issues" section. Don't be shy xD
 Please consider Star our repo to encourage us if this script is useful to you : )
 
 <p align="center">
-  <a href="https://imgur.com/a/c6vKI">
-    <img alt="Chaldea" src="https://camo.githubusercontent.com/19a9a5e1023613c01ba79aa1d03cae17d201f610/68747470733a2f2f7669676e65747465312e77696b69612e6e6f636f6f6b69652e6e65742f666174656772616e646f726465722f696d616765732f322f32642f4368616c6465615f53656375726974795f4f7267616e697a6174696f6e5f4c6f676f2e706e672f7265766973696f6e2f6c61746573742f7363616c652d746f2d77696474682d646f776e2f323030303f63623d3230313631313139303833333437" width="400"/>
-  </a>
+	<a href="https://imgur.com/a/c6vKI">
+		<img alt="Chaldea" src="https://camo.githubusercontent.com/19a9a5e1023613c01ba79aa1d03cae17d201f610/68747470733a2f2f7669676e65747465312e77696b69612e6e6f636f6f6b69652e6e65742f666174656772616e646f726465722f696d616765732f322f32642f4368616c6465615f53656375726974795f4f7267616e697a6174696f6e5f4c6f676f2e706e672f7265766973696f6e2f6c61746573742f7363616c652d746f2d77696474682d646f776e2f323030303f63623d3230313631313139303833333437" width="400"/>
+	</a>
 </p>
 
 [![Lua-5.1-Sikuli](https://cdn.rawgit.com/29988122/Fate-Grand-Order_Lua/ffdafd04/docs/Lua--Sikuli-5.1-blue.svg)](http://http://www.sikuli.org/)[![GitHub license](https://cdn.rawgit.com/29988122/Fate-Grand-Order_Lua/ffdafd04/docs/Fate-Grand-Order_Lua.svg)](https://github.com/29988122/Fate-Grand-Order_Lua/blob/master/LICENSE)
@@ -28,23 +28,22 @@ As of 2018.12.30, this script is **working without root** / without being blocke
 # Table of Contents:
 * [中文說明 マニュアル](#中文說明-マニュアル)
 * [Install](#install)
-  * [Android 8.1 and above](#android-81-and-above)
+	* [Android 8.1 and above](#android-81-and-above)
 * [Usage](#usage)
 * [Extra scripts](#extra-scripts)
 * [Events](#events)
 * [Advanced features](#advanced-features)
-  * [AutoSkill](#autoskill)
-    * [Chaldea Combat Uniform: Order Change](#chaldea-combat-uniform-order-change)
-    * [Targeting Enemies](#targeting-enemies)
-    * [Attack with Command Cards before NPs](#attack-with-command-cards-before-nps) 
-    * [AutoSkill List](#autoskill-list)
-  * [AutoRefill](#autorefill)
-  * [AutoSupportSelection](#autosupportselection)
-  * [Card Priority Customization](#card-priority-customization)
-  * [Auto Target Choosing](#auto-target-choosing)
-  * [Noble Phantasm Behavior](#noble-phantasm-behavior)
+	* [AutoSkill](#autoskill)
+		* [Chaldea Combat Uniform: Order Change](#chaldea-combat-uniform-order-change)
+		* [Targeting Enemies](#targeting-enemies)
+		* [Attack with Command Cards before NPs](#attack-with-command-cards-before-nps)
+	* [AutoRefill](#autorefill)
+	* [AutoSupportSelection](#autosupportselection)
+	* [Card Priority Customization](#card-priority-customization)
+	* [Auto Target Choosing](#auto-target-choosing)
+	* [Noble Phantasm Behavior](#noble-phantasm-behavior)
 * [Troubleshooting](#troubleshooting)
-  * [Syntax error: unexpected symbol near '燎](#syntax-error-unexpected-symbol-near-燎)
+	* [Syntax error: unexpected symbol near '燎](#syntax-error-unexpected-symbol-near-燎)
 * [Feature requests, 說明, 要望](#feature-requests)
 
 ***
@@ -142,6 +141,33 @@ ON = 1
 That is, if you need to click through confirmation window to use a skill, make this option ```Skill_Confirmation = 1```. 
 Otherwise, leave it as ```Skill_Confirmation = 0```.
 
+```Autoskill_List``` is where you setup predefined autoskill settings.
+The script would let you choose one from it when it starts running.
+This especially helps if you need to farm different stages during events.
+
+Every entry in ```Autoskill_List``` should have a ```Name``` and ```Skill_Command```. You can have any number of entries in ```Autoskill_List```.  
+Optionally, you can also override ```AutoSupportSelection``` options.
+
+e.g.
+```lua
+Autoskill_List =
+{
+	-- Setting 1 does not override AutoSupportSelection options
+	{
+		Name = "Party 1",
+		Skill_Command = "4,#,f5,#,i6"
+	},
+	-- Setting 2 overrides support selection method to preferred, Preferred Support servant to Any and CE to mona lisa.
+	{
+		Name = "QP",
+		Skill_Command = "4,#,f5,#,i6",
+		Support_SelectionMode = "preferred",
+		Support_PreferredServants = "",
+		Support_PreferredCEs = "*mona_lisa.png"
+	}
+}
+```
+
 ```Skill_Command``` strings should be composed by the following rules:
 ```
 ',' = Turn counter
@@ -218,11 +244,6 @@ Use 1 regular Command Card according to the priority from Battle_CardPriority, t
 Skill_Command = "n26"
 Use 2 regular Command Cards, then use the NP of the third Servant
 ```
-
-#### AutoSkill List
-Set ```Enable_Autoskill_List = 1``` to enable this feature.
-You can setup a predefined autoskill list from 1~10, and the script whould let you choose from it when it starts running.
-This especially helps if you need to farm different stages during events.
 
 ### AutoRefill:
 Set `Refill_Enabled = 1` to enable AutoRefill.

--- a/README.md
+++ b/README.md
@@ -146,13 +146,13 @@ The script would let you choose one from it when it starts running.
 This especially helps if you need to farm different stages during events.
 
 Every entry in ```Autoskill_List``` should have a ```Name``` and ```Skill_Command```. You can have any number of entries in ```Autoskill_List```.  
-Optionally, you can also override ```AutoSupportSelection``` options.
+Optionally, you can also override any globally defined option.
 
 e.g.
 ```lua
 Autoskill_List =
 {
-	-- Setting 1 does not override AutoSupportSelection options
+	-- Setting 1 does not override global options
 	{
 		Name = "Party 1",
 		Skill_Command = "4,#,f5,#,i6"
@@ -164,6 +164,12 @@ Autoskill_List =
 		Support_SelectionMode = "preferred",
 		Support_PreferredServants = "",
 		Support_PreferredCEs = "*mona_lisa.png"
+	},
+	-- Setting 3 overrides Card Priority
+	{
+		Name = "Quick",
+		Skill_Command = "d1g14,#,e14,#,h1fi4",
+		Battle_CardPriority = "QBA"
 	}
 }
 ```

--- a/middleware.lua
+++ b/middleware.lua
@@ -1,41 +1,41 @@
 setImagePath(dir)
 
 local function SetSupportOptions(selected_autoskill)
-  if selected_autoskill["Support_SelectionMode"] ~= nil then
-    Support_SelectionMode = selected_autoskill["Support_SelectionMode"]
-  end
+	if selected_autoskill["Support_SelectionMode"] ~= nil then
+		Support_SelectionMode = selected_autoskill["Support_SelectionMode"]
+	end
 
-  if selected_autoskill["Support_SwipesPerUpdate"] ~= nil then
-    Support_SwipesPerUpdate = selected_autoskill["Support_SwipesPerUpdate"]
-  end
+	if selected_autoskill["Support_SwipesPerUpdate"] ~= nil then
+		Support_SwipesPerUpdate = selected_autoskill["Support_SwipesPerUpdate"]
+	end
 
-  if selected_autoskill["Support_MaxUpdates"] ~= nil then
-    Support_MaxUpdates = selected_autoskill["Support_MaxUpdates"]
-  end
+	if selected_autoskill["Support_MaxUpdates"] ~= nil then
+		Support_MaxUpdates = selected_autoskill["Support_MaxUpdates"]
+	end
 
-  if selected_autoskill["Support_FallbackTo"] ~= nil then
-    Support_FallbackTo = selected_autoskill["Support_FallbackTo"]
-  end
+	if selected_autoskill["Support_FallbackTo"] ~= nil then
+		Support_FallbackTo = selected_autoskill["Support_FallbackTo"]
+	end
 
-  if selected_autoskill["Support_FriendsOnly"] ~= nil then
-    Support_FriendsOnly = selected_autoskill["Support_FriendsOnly"]
-  end
+	if selected_autoskill["Support_FriendsOnly"] ~= nil then
+		Support_FriendsOnly = selected_autoskill["Support_FriendsOnly"]
+	end
 
-  if selected_autoskill["Support_FriendNames"] ~= nil then
-    Support_FriendNames = selected_autoskill["Support_FriendNames"]
-  end
+	if selected_autoskill["Support_FriendNames"] ~= nil then
+		Support_FriendNames = selected_autoskill["Support_FriendNames"]
+	end
 
-  if selected_autoskill["Support_PreferredServants"] ~= nil then
-    Support_PreferredServants = selected_autoskill["Support_PreferredServants"]
-  end
+	if selected_autoskill["Support_PreferredServants"] ~= nil then
+		Support_PreferredServants = selected_autoskill["Support_PreferredServants"]
+	end
 
-  if selected_autoskill["Support_PreferredCEs"] ~= nil then
-    Support_PreferredCEs = selected_autoskill["Support_PreferredCEs"]
-  end
+	if selected_autoskill["Support_PreferredCEs"] ~= nil then
+		Support_PreferredCEs = selected_autoskill["Support_PreferredCEs"]
+	end
 end
 
 local function AddRefillInfoToDialog()
-  if Refill_Enabled == 1 then
+	if Refill_Enabled == 1 then
 		if Refill_Resource == "SQ" then
 			RefillType = "sq"
 		elseif Refill_Resource == "All Apples" then
@@ -59,36 +59,36 @@ local function AddRefillInfoToDialog()
 end
 
 local function AddAutoskillListToDialog()
-  -- Autoskill list dialogue content generation.
-  if Enable_Autoskill == 1 then
-    addTextView("Please select your predefined Autoskill setting:")
-    newRow()
-    addRadioGroup("AutoSkillIndex", 1)
+	-- Autoskill list dialogue content generation.
+	if Enable_Autoskill == 1 then
+		addTextView("Please select your predefined Autoskill setting:")
+		newRow()
+		addRadioGroup("AutoSkillIndex", 1)
 
-    for key, value in ipairs(Autoskill_List) 
-    do
-      addRadioButton(value["Name"], key)
-    end
-  end
+		for key, value in ipairs(Autoskill_List) 
+		do
+			addRadioButton(value["Name"], key)
+		end
+	end
 end
 
 --User option PSA dialogue. Also choosable list of perdefined skill.
 function PSADialogue()
-  dialogInit()
+	dialogInit()
 
-  AddRefillInfoToDialog()
-  AddAutoskillListToDialog()  
+	AddRefillInfoToDialog()
+	AddAutoskillListToDialog()  
 
-  --Show the generated dialogue.
-  dialogShow("CAUTION")
+	--Show the generated dialogue.
+	dialogShow("CAUTION")
 
-  if Enable_Autoskill == 1 then
-    --Put user selection into variables
-    local selected_autoskill = Autoskill_List[AutoSkillIndex]
-    Skill_Command = selected_autoskill["Skill_Command"]
+	if Enable_Autoskill == 1 then
+		--Put user selection into variables
+		local selected_autoskill = Autoskill_List[AutoSkillIndex]
+		Skill_Command = selected_autoskill["Skill_Command"]
 
-    SetSupportOptions(selected_autoskill)
-  end
+		SetSupportOptions(selected_autoskill)
+	end
 end
 
 PSADialogue()

--- a/middleware.lua
+++ b/middleware.lua
@@ -1,0 +1,96 @@
+setImagePath(dir)
+
+local function SetSupportOptions(selected_autoskill)
+  if selected_autoskill["Support_SelectionMode"] ~= nil then
+    Support_SelectionMode = selected_autoskill["Support_SelectionMode"]
+  end
+
+  if selected_autoskill["Support_SwipesPerUpdate"] ~= nil then
+    Support_SwipesPerUpdate = selected_autoskill["Support_SwipesPerUpdate"]
+  end
+
+  if selected_autoskill["Support_MaxUpdates"] ~= nil then
+    Support_MaxUpdates = selected_autoskill["Support_MaxUpdates"]
+  end
+
+  if selected_autoskill["Support_FallbackTo"] ~= nil then
+    Support_FallbackTo = selected_autoskill["Support_FallbackTo"]
+  end
+
+  if selected_autoskill["Support_FriendsOnly"] ~= nil then
+    Support_FriendsOnly = selected_autoskill["Support_FriendsOnly"]
+  end
+
+  if selected_autoskill["Support_FriendNames"] ~= nil then
+    Support_FriendNames = selected_autoskill["Support_FriendNames"]
+  end
+
+  if selected_autoskill["Support_PreferredServants"] ~= nil then
+    Support_PreferredServants = selected_autoskill["Support_PreferredServants"]
+  end
+
+  if selected_autoskill["Support_PreferredCEs"] ~= nil then
+    Support_PreferredCEs = selected_autoskill["Support_PreferredCEs"]
+  end
+end
+
+local function AddRefillInfoToDialog()
+  if Refill_Enabled == 1 then
+		if Refill_Resource == "SQ" then
+			RefillType = "sq"
+		elseif Refill_Resource == "All Apples" then
+			RefillType = "all apples"
+		elseif Refill_Resource == "Gold" then
+			RefillType = "gold apples"
+		elseif Refill_Resource == "Silver" then
+			RefillType = "silver apples"
+		else
+			RefillType = "bronze apples"
+		end
+		addTextView("Auto Refill Enabled:")
+		newRow()
+		addTextView("You are going to use")
+		newRow()
+		addTextView(Refill_Repetitions .. " " .. RefillType .. ", ")
+		newRow()
+		addTextView("remember to check those values everytime you execute the script!")
+		addSeparator()
+	end
+end
+
+local function AddAutoskillListToDialog()
+  -- Autoskill list dialogue content generation.
+  if Enable_Autoskill == 1 then
+    addTextView("Please select your predefined Autoskill setting:")
+    newRow()
+    addRadioGroup("AutoSkillIndex", 1)
+
+    for key, value in ipairs(Autoskill_List) 
+    do
+      addRadioButton(value["Name"], key)
+    end
+  end
+end
+
+--User option PSA dialogue. Also choosable list of perdefined skill.
+function PSADialogue()
+  dialogInit()
+
+  AddRefillInfoToDialog()
+  AddAutoskillListToDialog()  
+
+  --Show the generated dialogue.
+  dialogShow("CAUTION")
+
+  if Enable_Autoskill == 1 then
+    --Put user selection into variables
+    local selected_autoskill = Autoskill_List[AutoSkillIndex]
+    Skill_Command = selected_autoskill["Skill_Command"]
+
+    SetSupportOptions(selected_autoskill)
+  end
+end
+
+PSADialogue()
+
+dofile(dir .. "regular.lua")

--- a/middleware.lua
+++ b/middleware.lua
@@ -1,36 +1,13 @@
 setImagePath(dir)
 
-local function SetSupportOptions(selected_autoskill)
-	if selected_autoskill["Support_SelectionMode"] ~= nil then
-		Support_SelectionMode = selected_autoskill["Support_SelectionMode"]
-	end
-
-	if selected_autoskill["Support_SwipesPerUpdate"] ~= nil then
-		Support_SwipesPerUpdate = selected_autoskill["Support_SwipesPerUpdate"]
-	end
-
-	if selected_autoskill["Support_MaxUpdates"] ~= nil then
-		Support_MaxUpdates = selected_autoskill["Support_MaxUpdates"]
-	end
-
-	if selected_autoskill["Support_FallbackTo"] ~= nil then
-		Support_FallbackTo = selected_autoskill["Support_FallbackTo"]
-	end
-
-	if selected_autoskill["Support_FriendsOnly"] ~= nil then
-		Support_FriendsOnly = selected_autoskill["Support_FriendsOnly"]
-	end
-
-	if selected_autoskill["Support_FriendNames"] ~= nil then
-		Support_FriendNames = selected_autoskill["Support_FriendNames"]
-	end
-
-	if selected_autoskill["Support_PreferredServants"] ~= nil then
-		Support_PreferredServants = selected_autoskill["Support_PreferredServants"]
-	end
-
-	if selected_autoskill["Support_PreferredCEs"] ~= nil then
-		Support_PreferredCEs = selected_autoskill["Support_PreferredCEs"]
+-- Writes autoskill options into global variables
+local function ExtractAutoskillOptions(selected_autoskill)
+	for key, value in pairs(selected_autoskill) do
+		-- We don't want to make Name a global variable
+		if key ~= "Name" then
+			-- _G is global variable table
+			_G[key] = value
+		end
 	end
 end
 
@@ -85,9 +62,8 @@ function PSADialogue()
 	if Enable_Autoskill == 1 then
 		--Put user selection into variables
 		local selected_autoskill = Autoskill_List[AutoSkillIndex]
-		Skill_Command = selected_autoskill["Skill_Command"]
 
-		SetSupportOptions(selected_autoskill)
+		ExtractAutoskillOptions(selected_autoskill)
 	end
 end
 

--- a/regular.lua
+++ b/regular.lua
@@ -228,66 +228,6 @@ local function Support()
 	end
 end
 
---User option PSA dialogue. Also choosble list of perdefined skill.
-local function PSADialogue()
-	dialogInit()
-	--Auto Refill dialogue content generation.
-	if Refill_Enabled == 1 then
-		if Refill_Resource == "SQ" then
-			RefillType = "sq"
-		elseif Refill_Resource == "All Apples" then
-			RefillType = "all apples"
-		elseif Refill_Resource == "Gold" then
-			RefillType = "gold apples"
-		elseif Refill_Resource == "Silver" then
-			RefillType = "silver apples"
-		else
-			RefillType = "bronze apples"
-		end
-		addTextView("Auto Refill Enabled:")
-		newRow()
-		addTextView("You are going to use")
-		newRow()
-		addTextView(Refill_Repetitions .. " " .. RefillType .. ", ")
-		newRow()
-		addTextView("remember to check those values everytime you execute the script!")
-		addSeparator()
-	end
-
-	--Autoskill dialogue content generation.
-	if Enable_Autoskill == 1 then
-		addTextView("AutoSkill Enabled:")
-		newRow()
-		addTextView("Start the script from menu or Battle 1/3 to make it work properly.")
-		addSeparator()
-	end
-
-	--Autoskill list dialogue content generation.
-	if Enable_Autoskill_List == 1 then
-		addTextView("Please select your predefined Autoskill setting:")
-		newRow()
-		addRadioGroup("AutoskillListIndex", 1)
-		addRadioButton(Autoskill_List[1][1] .. ": " .. Autoskill_List[1][2], 1)
-		addRadioButton(Autoskill_List[2][1] .. ": " .. Autoskill_List[2][2], 2)
-		addRadioButton(Autoskill_List[3][1] .. ": " .. Autoskill_List[3][2], 3)
-		addRadioButton(Autoskill_List[4][1] .. ": " .. Autoskill_List[4][2], 4)
-		addRadioButton(Autoskill_List[5][1] .. ": " .. Autoskill_List[5][2], 5)
-		addRadioButton(Autoskill_List[6][1] .. ": " .. Autoskill_List[6][2], 6)
-		addRadioButton(Autoskill_List[7][1] .. ": " .. Autoskill_List[7][2], 7)
-		addRadioButton(Autoskill_List[8][1] .. ": " .. Autoskill_List[8][2], 8)
-		addRadioButton(Autoskill_List[9][1] .. ": " .. Autoskill_List[9][2], 9)
-		addRadioButton(Autoskill_List[10][1] .. ": " .. Autoskill_List[10][2], 10)
-	end
-
-	--Show the generated dialogue.
-	dialogShow("CAUTION")
-	
-	--Put user selection into list for later exception handling.
-	if Enable_Autoskill_List == 1 then
-		Skill_Command = Autoskill_List[AutoskillListIndex][2]
-	end
-end
-
 --[[
 	Initialize Aspect Ratio adjustment for different sized screens,ask for input from user for Autoskill plus confirming Apple/Stone usage
 	Then initialize the Autoskill, Battle, and Card modules in modules/.
@@ -295,8 +235,6 @@ end
 local function Init()
 	--Set only ONCE for every separated script run.
 	scaling.ApplyAspectRatioFix(SCRIPT_WIDTH, SCRIPT_HEIGHT, IMAGE_WIDTH, IMAGE_HEIGHT)
-
-	PSADialogue()
 
 	autoskill.Init(battle, card)
 	battle.init(autoskill, card)


### PR DESCRIPTION
Requested in #101

I've added a `middleware.lua` file and moved the `PSADialogue` function into it.

The flow is like: `FGO_REGULAR.lua -> middleware.lua -> regular.lua`

`Autoskill_List` array is now defined by the user instead of being restricted to 10 items.
Each entry should have `Name` and `Skill_Command` members.
Optionally, `AutoSupportSelection` options like `Support_SelectionMode`, `Support_SwipesPerUpdate`, `Support_MaxUpdates`, etc can be used to override the corresponding options defined outside the AutoSkill list.

I removed the `Enable_Autoskill_List` variable. I think `Enable_Autoskill` should be sufficient alone.