### PR TITLE
Default values for options

### DIFF
--- a/FGO_REGULAR.lua
+++ b/FGO_REGULAR.lua
@@ -51,6 +51,18 @@ Battle_AutoChooseTarget = 1
 --NoblePhantasm Casting
 Battle_NoblePhantasm = "disabled"
 
+-- set to 'true' if needing to debug
+Debug_Mode = false
+-- stop the script after retreiving a Bond 10 CE card
+StopAfterBond10 = 0
+-- Boost item, possible values: disabled, 1, 2 or 3. Make sure "Confirm Use of Boost Item" is off
+BoostItem_SelectionMode = "disabled"
+StorySkip = 0
+--Auto Withdrawing
+Withdraw_Enabled = false
+--FastSkipDeadAnimation
+UnstableFastSkipDeadAnimation = 0
+
 -- Do not modify below this line
 dir = scriptPath()
 dofile(dir .. "middleware.lua")

--- a/FGO_REGULAR.lua
+++ b/FGO_REGULAR.lua
@@ -1,9 +1,7 @@
-Debug_Mode = false -- set to 'true' if needing to debug
-
 -- Can be EN, JP, CN or TW
 GameRegion = "EN"
 
---Script Configuration, check instructions here: https://github.com/29988122/Fate-Grand-Order_Lua/wiki/Script-configuration-English
+--Script Configuration, check instructions in the README and wiki: https://github.com/29988122/Fate-Grand-Order_Lua/wiki/Script-configuration-English
 --***************************************************************************
 --AutoRefill Stamina
 Refill_Enabled = 0
@@ -19,29 +17,6 @@ Support_FriendsOnly = 0
 Support_FriendNames = ""
 Support_PreferredServants = "waver4.png, waver3.png, waver2.png, waver1.png"
 Support_PreferredCEs = "*chaldea_lunchtime.png"
-
---Bond CE Get
-StopAfterBond10 = 0--[[
-	This option is switched to 1 if you want to stop the script after retreiving a Bond 10 CE card
-	TODO: move this explanation to documentation
---]]
-
---BoostItem
-BoostItem_SelectionMode = "disabled" --[[
-	possible values: disabled, 1, 2 or 3
-	if you want to use this, make sure "Confirm Use of Boost Item" is off
-	
-	TODO: move this explanation to the documentation
---]]
-
-StorySkip = 0 --[[
-	People really want this feature.
-]]
-
---Auto Withdrawing
-Withdraw_Enabled = false --[[
-	Set this to true if you want to automatically withdraw and try the quest again when all your Servants have been defeated.
-]]
 
 --AutoSkill
 Enable_Autoskill = 0
@@ -74,9 +49,7 @@ Battle_CardPriority = "BAQ"
 --AutoChooseTarget
 Battle_AutoChooseTarget = 1
 --NoblePhantasm Casting
-Battle_NoblePhantasm = "disabled" 
---FastSkipDeadAnimation
-UnstableFastSkipDeadAnimation = 0
+Battle_NoblePhantasm = "disabled"
 
 -- Do not modify below this line
 dir = scriptPath()

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ As of 2018.12.30, this script is **working without root** / without being blocke
 	* [Card Priority Customization](#card-priority-customization)
 	* [Auto Target Choosing](#auto-target-choosing)
 	* [Noble Phantasm Behavior](#noble-phantasm-behavior)
+* [More script options](#more-script-options)
 * [Troubleshooting](#troubleshooting)
 	* [Syntax error: unexpected symbol near '燎](#syntax-error-unexpected-symbol-near-燎)
 * [Feature requests, 說明, 要望](#feature-requests)
@@ -320,7 +321,49 @@ The script will cast NPs only when there are DANGER or SERVANT enemies on the sc
 ```Battle_NoblePhantasm = "spam"```
 The script will cast NPs as soon as they are available.
 
-If you have ```Enable_Autoskill = 1```, the above options applied after all of your predefined skills/NPs finished casting. 
+If you have ```Enable_Autoskill = 1```, the above options applied after all of your predefined skills/NPs finished casting.
+
+## More script options
+These are some optional features you can use in your scripts
+
+### Debug_Mode
+Debug mode highlights the region of the game recognized by the script on your screen instead of actually running the script. To enable, set:
+```lua
+Debug_Mode = true
+```
+
+### StopAfterBond10
+If you want to stop the script after retreiving a Bond 10 CE card, set:
+```lua
+StopAfterBond10 = 1
+```
+
+### BoostItem_SelectionMode
+Enables the use of event boost items.
+
+Possible values: `disabled` (default), `1`, `2` or `3`.
+
+If you want to use this, make sure **Confirm Use of Boost Item** is off.
+
+### StorySkip
+If you want the script to automatically skip story scenes, set:
+```lua
+StorySkip = 1
+```
+
+### Withdraw_Enabled
+If you want to automatically withdraw and try the quest again when all your Servants have been defeated, set:
+```lua
+Withdraw_Enabled = true
+```
+
+### UnstableFastSkipDeadAnimation
+If you want to skip the death animations, set:
+```lua
+UnstableFastSkipDeadAnimation = 1
+```
+
+This feature is unstable, so its use is not recommended.
 
 ## Troubleshooting
 Known issues are listed here.

--- a/middleware.lua
+++ b/middleware.lua
@@ -8,7 +8,30 @@ local function ApplyDefaults()
 		Debug_Mode = false,
 		StopAfterBond10 = 0,
 		UnstableFastSkipDeadAnimation = 0,
-		Withdraw_Enabled = false
+		Withdraw_Enabled = false,
+
+		GameRegion = "EN",
+
+		Refill_Enabled = 0,
+		Refill_Resource = "All Apples",
+		Refill_Repetitions = 0,
+
+		Support_SelectionMode = "first",
+		Support_SwipesPerUpdate = 10,
+		Support_MaxUpdates = 3,
+		Support_FallbackTo = "manual",
+		Support_FriendsOnly = 0,
+		Support_FriendNames = "",
+		Support_PreferredServants = "",
+		Support_PreferredCEs = "",
+
+		Enable_Autoskill = 0,
+		Skill_Confirmation = 0,
+		Autoskill_List = { },
+
+		Battle_CardPriority = "BAQ",
+		Battle_AutoChooseTarget = 1,
+		Battle_NoblePhantasm = "disabled"
 	}
 
 	for key, defaultValue in pairs(Defaults) do

--- a/middleware.lua
+++ b/middleware.lua
@@ -1,5 +1,25 @@
 setImagePath(dir)
 
+local function ApplyDefaults()
+	local Defaults =
+	{
+		BoostItem_SelectionMode = "disabled",
+		Story_Skip = 0,
+		Debug_Mode = false,
+		StopAfterBond10 = 0,
+		UnstableFastSkipDeadAnimation = 0,
+		Withdraw_Enabled = false
+	}
+
+	for key, defaultValue in pairs(Defaults) do
+		globalValue = _G[key]
+		
+		if globalValue == nil then
+			_G[key] = defaultValue
+		end
+	end
+end
+
 -- Writes autoskill options into global variables
 local function ExtractAutoskillOptions(selected_autoskill)
 	for key, value in pairs(selected_autoskill) do
@@ -67,6 +87,7 @@ function PSADialogue()
 	end
 end
 
+ApplyDefaults()
 PSADialogue()
 
 dofile(dir .. "regular.lua")

--- a/modules/support.lua
+++ b/modules/support.lua
@@ -168,19 +168,17 @@ selectPreferred = function(searchMethod)
 end
 
 scrollList = function()
-	-- local touchActions = {
-	-- 	{ action = "touchDown", target = game.SUPPORT_SWIPE_START_CLICK },
-	-- 	{ action = "touchMove", target = game.SUPPORT_SWIPE_END_CLICK },
-	-- 	{ action =      "wait", target = 0.4 },
-	-- 	{ action =   "touchUp", target = game.SUPPORT_SWIPE_END_CLICK },
-	-- 	{ action =      "wait", target = 0.5 } -- leaving some room for animations to finish
-	-- }
+	local touchActions = {
+		{ action = "touchDown", target = game.SUPPORT_SWIPE_START_CLICK },
+		{ action = "touchMove", target = game.SUPPORT_SWIPE_END_CLICK },
+		{ action =      "wait", target = 0.4 },
+		{ action =   "touchUp", target = game.SUPPORT_SWIPE_END_CLICK },
+		{ action =      "wait", target = 0.5 } -- leaving some room for animations to finish
+	}
 
-	-- -- the movement has to be as accurate as possible
-	-- setManualTouchParameter(5, 5)
-	-- manualTouch(touchActions)
-
-	swipe(game.SUPPORT_SWIPE_START_CLICK, game.SUPPORT_SWIPE_END_CLICK)
+	-- the movement has to be as accurate as possible
+	setManualTouchParameter(5, 5)
+	manualTouch(touchActions)
 end
 
 searchVisible = function(searchMethod)

--- a/modules/support.lua
+++ b/modules/support.lua
@@ -168,17 +168,19 @@ selectPreferred = function(searchMethod)
 end
 
 scrollList = function()
-	local touchActions = {
-		{ action = "touchDown", target = game.SUPPORT_SWIPE_START_CLICK },
-		{ action = "touchMove", target = game.SUPPORT_SWIPE_END_CLICK },
-		{ action =      "wait", target = 0.4 },
-		{ action =   "touchUp", target = game.SUPPORT_SWIPE_END_CLICK },
-		{ action =      "wait", target = 0.5 } -- leaving some room for animations to finish
-	}
+	-- local touchActions = {
+	-- 	{ action = "touchDown", target = game.SUPPORT_SWIPE_START_CLICK },
+	-- 	{ action = "touchMove", target = game.SUPPORT_SWIPE_END_CLICK },
+	-- 	{ action =      "wait", target = 0.4 },
+	-- 	{ action =   "touchUp", target = game.SUPPORT_SWIPE_END_CLICK },
+	-- 	{ action =      "wait", target = 0.5 } -- leaving some room for animations to finish
+	-- }
 
-	-- the movement has to be as accurate as possible
-	setManualTouchParameter(5, 5)
-	manualTouch(touchActions)
+	-- -- the movement has to be as accurate as possible
+	-- setManualTouchParameter(5, 5)
+	-- manualTouch(touchActions)
+
+	swipe(game.SUPPORT_SWIPE_START_CLICK, game.SUPPORT_SWIPE_END_CLICK)
 end
 
 searchVisible = function(searchMethod)

--- a/regular.lua
+++ b/regular.lua
@@ -86,26 +86,20 @@ end
 local function StartQuest()
 	click(game.MENU_START_QUEST_CLICK)
 
-	-- old scripts might not have this option set
-	-- don't wanna force everyone to update their configs
-	if BoostItem_SelectionMode ~= nil then	
-		if game.MENU_BOOST_ITEM_CLICK_ARRAY[BoostItem_SelectionMode] ~= nil then
-			wait(2)
-			click(game.MENU_BOOST_ITEM_CLICK_ARRAY[BoostItem_SelectionMode])
-			click(game.MENU_BOOST_ITEM_SKIP_CLICK) -- in case you run out of items
-		else
-			scriptExit("Invalid boost item selection mode: \"" + BoostItem_SelectionMode + "\".")
-		end
+	if game.MENU_BOOST_ITEM_CLICK_ARRAY[BoostItem_SelectionMode] ~= nil then
+		wait(2)
+		click(game.MENU_BOOST_ITEM_CLICK_ARRAY[BoostItem_SelectionMode])
+		click(game.MENU_BOOST_ITEM_SKIP_CLICK) -- in case you run out of items
+	else
+		scriptExit("Invalid boost item selection mode: \"" + BoostItem_SelectionMode + "\".")
 	end
-
-	if StorySkip ~= nil then
-		if StorySkip == 1 then
-			wait(10)
-			if game.MENU_STORY_SKIP_REGION:exists(GeneralImagePath .. "storyskip.png") then
-				click(game.MENU_STORY_SKIP_CLICK)
-				wait(0.5)
-				click(game.MENU_STORY_SKIP_YES_CLICK)
-			end
+	
+	if StorySkip == 1 then
+		wait(10)
+		if game.MENU_STORY_SKIP_REGION:exists(GeneralImagePath .. "storyskip.png") then
+			click(game.MENU_STORY_SKIP_CLICK)
+			wait(0.5)
+			click(game.MENU_STORY_SKIP_YES_CLICK)
 		end
 	end
 end
@@ -145,10 +139,8 @@ local function Result()
 	--Checking if there was a Bond CE reward
 	if game.RESULT_CE_REWARD_REGION:exists(GeneralImagePath .. "ce_reward.png") ~= nil then
 		
-		if StopAfterBond10 ~= nil then --Making sure they can still run it without updating FGO_REGULAR files
-			if StopAfterBond10 == 1 then
-				scriptExit("Bond 10 CE GET!")
-			end
+		if StopAfterBond10 == 1 then
+			scriptExit("Bond 10 CE GET!")
 		end
 		
 		click(game.RESULT_CE_REWARD_CLOSE_CLICK)
@@ -184,13 +176,11 @@ local function Result()
 	end
 
 	--Post-battle story is sometimes there.
-	if StorySkip ~= nil then
-		if StorySkip == 1 then
-			if game.MENU_STORY_SKIP_REGION:exists(GeneralImagePath .. "storyskip.png") then
-				click(game.MENU_STORY_SKIP_CLICK)
-				wait(0.5)
-				click(game.MENU_STORY_SKIP_YES_CLICK)
-			end
+	if StorySkip == 1 then
+		if game.MENU_STORY_SKIP_REGION:exists(GeneralImagePath .. "storyskip.png") then
+			click(game.MENU_STORY_SKIP_CLICK)
+			wait(0.5)
+			click(game.MENU_STORY_SKIP_YES_CLICK)
 		end
 	end
 


### PR DESCRIPTION
This PR adds code for automatically setting defaults, if the user did not specify some options in their script. This would allow to reduce clutter in the script, the user would only need to specify the options they want.
I've removed a few options from the `FGO_REGULAR.lua` file and wrote about them in `README.md`.

Instead of checking if the user has defined the variable or not like it is done for `BoostItem_SelectionMode`. We could keep a `Defaults` table and fill missing values from it.
So, the other modules can access those variables without worrying about them being `nil`.

```lua
local Defaults = {
    BoostItem_SelectionMode = "disabled",
    Story_Skip = 0,
    Debug_Mode = false,
    StopAfterBond10 = 0,
    UnstableFastSkipDeadAnimation = 0
    -- and more
}

for key, defaultValue in pairs(Defaults) do
	globalValue = _G[key]
	
	if globalValue == nil then
		_G[key] = defaultValue
	end
end
```