### PR TITLE
Add Support Image Maker script

### DIFF
--- a/_support_img_maker.lua
+++ b/_support_img_maker.lua
@@ -34,7 +34,7 @@ for _, testRegion in ipairs(regionArray) do
   supportBound:setY(testRegion:getY() - 70 + 68 * 2)
 
   if ankuluaUtils.DoesRegionContain(screenBounds, supportBound) then
-    local servantBound = Region(supportBound:getX(), supportBound:getY(), supportBound:getW(), 88)
+    local servantBound = Region(supportBound:getX(), supportBound:getY(), 250, 88)
     servantBound:save('servant_' .. i .. '.png')
 
     local ceBound = Region(supportBound:getX(), supportBound:getY() + 160, supportBound:getW(), 60)

--- a/_support_img_maker.lua
+++ b/_support_img_maker.lua
@@ -51,5 +51,5 @@ end
 if i == 0 then
   scriptExit("No support images were found on the current screen")
 else
-  scriptExit(i .. " servant and ce images stored into '" .. folder .. "' folder")
+  scriptExit(i .. " Servant and CE images have been stored in the  folder '" .. folder .. "'")
 end

--- a/_support_img_maker.lua
+++ b/_support_img_maker.lua
@@ -1,0 +1,45 @@
+dir = scriptPath()
+package.path = package.path .. ";" .. dir .. 'modules/?.lua'
+setImagePath(dir)
+
+local ankuluaUtils = require("ankulua-utils")
+local scaling = require("scaling")
+
+GameRegion = "EN"
+GeneralImagePath = "image_" .. GameRegion .. "/"
+
+local IMAGE_WIDTH = 1280
+local IMAGE_HEIGHT = 720
+local SCRIPT_WIDTH = 2560
+local SCRIPT_HEIGHT = 1440
+
+scaling.ApplyAspectRatioFix(SCRIPT_WIDTH, SCRIPT_HEIGHT, IMAGE_WIDTH, IMAGE_HEIGHT)
+
+-- Single screenshot is enough
+snapshot()
+
+local supportBound = Region(106,0,286,220)
+local regionAnchor = Pattern(GeneralImagePath .. "support_region_tool.png")
+local regionArray = regionFindAllNoFindException(Region(2100,0,300,1440), regionAnchor)
+local screenBounds = Region(0,0,SCRIPT_WIDTH,SCRIPT_HEIGHT)
+
+local i = 0
+
+for _, testRegion in ipairs(regionArray) do
+  -- At max two Servant+CE are completely on screen
+  if i > 1 then
+    break
+  end
+
+  supportBound:setY(testRegion:getY() - 70 + 68 * 2)
+
+  if ankuluaUtils.DoesRegionContain(screenBounds, supportBound) then
+    local servantBound = Region(supportBound:getX(), supportBound:getY(), supportBound:getW(), 88)
+    servantBound:save('servant_' .. i .. '.png')
+
+    local ceBound = Region(supportBound:getX(), supportBound:getY() + 160, supportBound:getW(), 60)
+    ceBound:save('ce_' .. i .. '.png')
+
+    i = i + 1
+  end
+end

--- a/_support_img_maker.lua
+++ b/_support_img_maker.lua
@@ -49,7 +49,7 @@ for _, testRegion in ipairs(regionArray) do
 end
 
 if i == 0 then
-  scriptExit("No images generated")
+  scriptExit("No support images were found on the current screen")
 else
   scriptExit(i .. " servant and ce images stored into '" .. folder .. "' folder")
 end

--- a/_support_img_maker.lua
+++ b/_support_img_maker.lua
@@ -23,6 +23,10 @@ local regionAnchor = Pattern(GeneralImagePath .. "support_region_tool.png")
 local regionArray = regionFindAllNoFindException(Region(2100,0,300,1440), regionAnchor)
 local screenBounds = Region(0,0,SCRIPT_WIDTH,SCRIPT_HEIGHT)
 
+local datetime = os.date('%Y%m%d-%H%M%S')
+local folder = 'support_' .. datetime .. '/'
+os.execute('mkdir ' .. dir .. '/' .. folder)
+
 local i = 0
 
 for _, testRegion in ipairs(regionArray) do
@@ -35,11 +39,17 @@ for _, testRegion in ipairs(regionArray) do
 
   if ankuluaUtils.DoesRegionContain(screenBounds, supportBound) then
     local servantBound = Region(supportBound:getX(), supportBound:getY(), 250, 88)
-    servantBound:save('servant_' .. i .. '.png')
+    servantBound:save(folder .. 'servant_' .. i .. '.png')
 
     local ceBound = Region(supportBound:getX(), supportBound:getY() + 160, supportBound:getW(), 60)
-    ceBound:save('ce_' .. i .. '.png')
+    ceBound:save(folder .. 'ce_' .. i .. '.png')
 
     i = i + 1
   end
+end
+
+if i == 0 then
+  scriptExit("No images generated")
+else
+  scriptExit(i .. " servant and ce images stored into '" .. folder .. "' folder")
 end


### PR DESCRIPTION
I've added a script that can make images that can be used with Auto Support Selection.
The generated images are black and white, but that is not a problem because AnkuLua matches images in black and white.

I've added the scaling script into it so I think it should also work fine on phones with a notch too.

To run the script, select it in AnkuLua, go to support selection screen and press Play.
The script ends almost immediately.
For images to be saved, the Servant+corresponding CE should be completely on screen.
Only 2 Servant+CE can be completely on screen at a time.
The images are stored in the same directory as the script and named as: `ce_0.png, ce_1.png, servant_0.png, servant_1.png`.

Some generated images:
![servant_0.png](https://user-images.githubusercontent.com/10654537/79070272-56e50180-7cf2-11ea-85a0-9cf552ea44cd.jpeg)
![ce_0.png](https://user-images.githubusercontent.com/10654537/79070275-5b111f00-7cf2-11ea-991f-f3ed593c3b7f.jpeg)
