### PR TITLE
Support Image Maker script can be used from Friend List

### DIFF
--- a/_support_img_maker.lua
+++ b/_support_img_maker.lua
@@ -4,6 +4,7 @@ setImagePath(dir)
 
 local ankuluaUtils = require("ankulua-utils")
 local scaling = require("scaling")
+local game = require("game")
 
 GameRegion = "EN"
 GeneralImagePath = "image_" .. GameRegion .. "/"
@@ -17,6 +18,9 @@ scaling.ApplyAspectRatioFix(SCRIPT_WIDTH, SCRIPT_HEIGHT, IMAGE_WIDTH, IMAGE_HEIG
 
 -- Single screenshot is enough
 snapshot()
+
+--Checks if Support Selection menu is up
+local isSupportScreen =	game.SUPPORT_SCREEN_REGION:exists(Pattern(GeneralImagePath .. "support_screen.png"):similar(.85))
 
 local supportBound = Region(106,0,286,220)
 local regionAnchor = Pattern(GeneralImagePath .. "support_region_tool.png")
@@ -35,13 +39,18 @@ for _, testRegion in ipairs(regionArray) do
     break
   end
 
-  supportBound:setY(testRegion:getY() - 70 + 68 * 2)
+  if isSupportScreen then
+    supportBound:setY(testRegion:getY() - 70 + 68 * 2)
+  else -- Assume we are on Friend List
+    supportBound:setY(testRegion:getY() + 82)
+    supportBound = ankuluaUtils.AddX(supportBound, 10)
+  end
 
   if ankuluaUtils.DoesRegionContain(screenBounds, supportBound) then
     local servantBound = Region(supportBound:getX(), supportBound:getY(), 250, 88)
     servantBound:save(folder .. 'servant_' .. i .. '.png')
 
-    local ceBound = Region(supportBound:getX(), supportBound:getY() + 160, supportBound:getW(), 60)
+    local ceBound = Region(supportBound:getX(), supportBound:getY() + 160, supportBound:getW(), 50)
     ceBound:save(folder .. 'ce_' .. i .. '.png')
 
     i = i + 1

--- a/_support_img_maker.lua
+++ b/_support_img_maker.lua
@@ -58,7 +58,7 @@ for _, testRegion in ipairs(regionArray) do
 end
 
 if i == 0 then
-  scriptExit("No support images were found on the current screen")
+  scriptExit("No support images were found. Make sure you're in the Support Selection or in the Friend List and that the correct GameRegion is set in the script.")
 else
   scriptExit(i .. " Servant and CE images have been stored in the  folder '" .. folder .. "'")
 end


### PR DESCRIPTION
Making the `_support_img_maker.lua` script usable on Friend List.
Also, adjusted the height of the generated image for CEs to remove MLB star.

~~I'll mark as *Ready for Review* once I'm done testing.~~